### PR TITLE
Theme color

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Then, go to your browser [http://localhost:3000](http://localhost:3000).
 
     [http://localhost:3000/?theme=sample](http://localhost:3000/?theme=sample)
 
-2. To switch style, pass `style` param. By default, it will pick up the style from 'listing.instant_website.style_name'. In this sandbox app, it could have one of these twos: `blue` or `gray`.
+2. To switch color, pass `color` param. By default, it will pick up the color from 'listing.instant_website.color'. In this sandbox app, it could have one of these twos: `blue` or `gray`.
 
-    [http://localhost:3000/?style=gray](http://localhost:3000/?style=gray)
+    [http://localhost:3000/?color=gray](http://localhost:3000/?color=gray)
 
 2. To switch locale, pass `locale` param. By default, it will pick up from current listing's locale.
 
@@ -68,7 +68,7 @@ Then, go to your browser [http://localhost:3000](http://localhost:3000).
 To generate theme inside your app:
 
     $ rails g instant_website:theme theme_name
-    
+
 To validate your themes:
 
     $ rake

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,7 +80,7 @@ class ApplicationController < ActionController::Base
 
     def set_theme_color_url
       params[:color] =  params[:color].presence ||
-                        current_listing.instant_website.color.presence ||
+                        current_listing.instant_website.color_name.presence ||
                         current_listing.instant_website.template.colors.first.try(:name)
 
       @theme_color_url = if params[:color].present?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,14 +11,14 @@ class ApplicationController < ActionController::Base
   before_action :set_i18n
   theme         :theme_resolver
   before_action :set_template
-  before_action :set_theme_style_url
+  before_action :set_theme_color_url
 
   def current_listing
     @listing
   end
 
-  def theme_style_url
-    @theme_style_url
+  def theme_color_url
+    @theme_color_url
   end
 
   protected
@@ -78,13 +78,13 @@ class ApplicationController < ActionController::Base
       @i18n = Yoolk::Liquid::I18nDrop.new
     end
 
-    def set_theme_style_url
-      params[:style] =  params[:style].presence ||
-                        current_listing.instant_website.style_name.presence ||
-                        current_listing.instant_website.template.styles.first
+    def set_theme_color_url
+      params[:color] =  params[:color].presence ||
+                        current_listing.instant_website.color.presence ||
+                        current_listing.instant_website.template.colors.first.try(:name)
 
-      @theme_style_url = if params[:style].present?
-        "#{params[:theme]}/all_#{params[:style]}"
+      @theme_color_url = if params[:color].present?
+        "#{params[:theme]}/all_#{params[:color]}"
       else
         "#{params[:theme]}/all"
       end

--- a/app/themes/sample/views/layouts/sample.liquid
+++ b/app/themes/sample/views/layouts/sample.liquid
@@ -9,7 +9,7 @@
 <body data-class-name="{{ request.js_class_name }}">
   {% draft_stamp %}
   {% include 'shared/nav' %}
-  <div class="main-container main-container-style-{{request.style_name}}">
+  <div class="main-container main-container-style-{{request.theme_color}}">
     {% include 'shared/breadcrumb' %}
     {{ content_for_layout }}
   </div>

--- a/app/themes/sample/views/shared/_nav.liquid
+++ b/app/themes/sample/views/shared/_nav.liquid
@@ -1,4 +1,4 @@
-<div class="nav nav-style-{{request.style_name}}">
+<div class="nav nav-style-{{request.theme_color}}">
   <div class="side-nav">
     {% if listing.logo != blank %}
       {{ listing.logo | attachment_url: 'medium' | image_tag | link_to_home }}

--- a/db/samples/jsons/listings/kh1.json
+++ b/db/samples/jsons/listings/kh1.json
@@ -1445,7 +1445,7 @@
     "is_live": false,
     "is_active": true,
     "free_plan": false,
-    "color": "gray",
+    "color_name": "gray",
     "template": {
       "id": 1,
       "name": "sample",

--- a/db/samples/jsons/listings/kh1.json
+++ b/db/samples/jsons/listings/kh1.json
@@ -182,7 +182,6 @@
       "updated_at": "2014-08-13 08:59:54 UTC"
     }
   ],
-
   "links": [
     {
       "id": 1,
@@ -1442,15 +1441,18 @@
   "instant_website": {
     "id": "1",
     "name": "sample",
-    "display_name": "Sample Theme",
-    "developed_by": "Yoolk Inc.",
     "google_analytics_key": "333333",
     "is_live": false,
     "is_active": true,
     "free_plan": false,
     "color": "gray",
     "template": {
+      "id": 1,
       "name": "sample",
+      "display_name": "Sample Theme",
+      "developed_by": "Yoolk Inc.",
+      "developer_url": "http://www.yoolk.com",
+      "demo_website": "http://groow.io",
       "description": "Sample Theme developed by Yoolk Inc.",
       "is_responsive": true,
       "industries": [

--- a/db/samples/jsons/listings/kh1.json
+++ b/db/samples/jsons/listings/kh1.json
@@ -1441,33 +1441,35 @@
   ],
   "instant_website": {
     "id": "1",
+    "name": "sample",
+    "display_name": "Sample Theme",
+    "developed_by": "Yoolk Inc.",
     "google_analytics_key": "333333",
     "is_live": false,
     "is_active": true,
     "free_plan": false,
-    "style_name": "gray",
+    "color": "gray",
     "template": {
       "name": "sample",
-      "description": "",
+      "description": "Sample Theme developed by Yoolk Inc.",
       "is_responsive": true,
       "industries": [
         "Clothing & Fashion",
         "Media & Advertising",
         "Optical Products"
       ],
-      "styles": [
-        "gray",
-        "black",
-        "blue",
-        "brown",
-        "green",
-        "lblue",
-        "less",
-        "orange",
-        "purple",
-        "red",
-        "rose",
-        "yellow"
+      "colors": [
+        { "name": "gray", "code": "#808080" },
+        { "name": "black", "code": "#000000" },
+        { "name": "blue", "code": "#0000FF" },
+        { "name": "brown", "code": "#A52A2A" },
+        { "name": "green", "code": "#008000" },
+        { "name": "lblue", "code": "#ADD8E6" },
+        { "name": "orange", "code": "#FFA500" },
+        { "name": "purple", "code": "#800080" },
+        { "name": "red", "code": "#FF0000" },
+        { "name": "rose", "code": "#FFE4E1" },
+        { "name": "yellow", "code": "#FFFF00" }
       ],
       "pages": [
         "Galleries",

--- a/db/samples/jsons/templates/sample.json
+++ b/db/samples/jsons/templates/sample.json
@@ -1,12 +1,35 @@
 {
+  "id": "1",
   "name": "sample",
-  "description": "",
-  "is_responsive": true,
-  "industries": [
-    "Clothing & Fashion",
-    "Media & Advertising",
-    "Optical Products"
-  ],
+  "display_name": "Sample Theme",
+  "developed_by": "Yoolk Inc.",
+  "google_analytics_key": "333333",
+  "is_live": false,
+  "is_active": true,
+  "free_plan": false,
+  "color": "gray",
+  "template": {
+    "name": "sample",
+    "description": "Sample Theme developed by Yoolk Inc.",
+    "is_responsive": true,
+    "industries": [
+      "Clothing & Fashion",
+      "Media & Advertising",
+      "Optical Products"
+    ],
+    "colors": [
+      { "name": "gray", "code": "#808080" },
+      { "name": "black", "code": "#000000" },
+      { "name": "blue", "code": "#0000FF" },
+      { "name": "brown", "code": "#A52A2A" },
+      { "name": "green", "code": "#008000" },
+      { "name": "lblue", "code": "#ADD8E6" },
+      { "name": "orange", "code": "#FFA500" },
+      { "name": "purple", "code": "#800080" },
+      { "name": "red", "code": "#FF0000" },
+      { "name": "rose", "code": "#FFE4E1" },
+      { "name": "yellow", "code": "#FFFF00" }
+    ],
   "pages": [
     "Galleries",
     "Products",

--- a/db/samples/jsons/templates/sample.json
+++ b/db/samples/jsons/templates/sample.json
@@ -3,33 +3,25 @@
   "name": "sample",
   "display_name": "Sample Theme",
   "developed_by": "Yoolk Inc.",
-  "google_analytics_key": "333333",
-  "is_live": false,
-  "is_active": true,
-  "free_plan": false,
-  "color": "gray",
-  "template": {
-    "name": "sample",
-    "description": "Sample Theme developed by Yoolk Inc.",
-    "is_responsive": true,
-    "industries": [
-      "Clothing & Fashion",
-      "Media & Advertising",
-      "Optical Products"
-    ],
-    "colors": [
-      { "name": "gray", "code": "#808080" },
-      { "name": "black", "code": "#000000" },
-      { "name": "blue", "code": "#0000FF" },
-      { "name": "brown", "code": "#A52A2A" },
-      { "name": "green", "code": "#008000" },
-      { "name": "lblue", "code": "#ADD8E6" },
-      { "name": "orange", "code": "#FFA500" },
-      { "name": "purple", "code": "#800080" },
-      { "name": "red", "code": "#FF0000" },
-      { "name": "rose", "code": "#FFE4E1" },
-      { "name": "yellow", "code": "#FFFF00" }
-    ],
+  "is_responsive": true,
+  "industries": [
+    "Clothing & Fashion",
+    "Media & Advertising",
+    "Optical Products"
+  ],
+  "colors": [
+    { "name": "gray", "code": "#808080" },
+    { "name": "black", "code": "#000000" },
+    { "name": "blue", "code": "#0000FF" },
+    { "name": "brown", "code": "#A52A2A" },
+    { "name": "green", "code": "#008000" },
+    { "name": "lblue", "code": "#ADD8E6" },
+    { "name": "orange", "code": "#FFA500" },
+    { "name": "purple", "code": "#800080" },
+    { "name": "red", "code": "#FF0000" },
+    { "name": "rose", "code": "#FFE4E1" },
+    { "name": "yellow", "code": "#FFFF00" }
+  ],
   "pages": [
     "Galleries",
     "Products",


### PR DESCRIPTION
Style has been renamed to 'color'. These below two methods are deprecated:
1. `request.style_name` => `request.theme_color`
2. `request.theme_style_url` => `request.theme_color_url`

To switch the color, pass the `color` instead of `style`.

This PR depends on this https://github.com/yoolk/yoolk_core/pull/311, https://github.com/yoolk/yoolk_liquid/pull/43, and https://github.com/yoolk/yoolk_instant_website/pull/339.